### PR TITLE
Updating service name to Elastic Container Service

### DIFF
--- a/doc_source/troubleshoot-task-iam-roles.md
+++ b/doc_source/troubleshoot-task-iam-roles.md
@@ -29,9 +29,9 @@ The following procedure helps you to:
 
    1. In the navigation pane, choose **Roles**, **Create role**\. 
 
-   1. For **Select type of trusted entity**, choose **EC2 Container Service**\.
+   1. For **Select type of trusted entity**, choose **Elastic Container Service**\.
 
-   1. For **Select your use case**, choose **EC2 Container Service Task**, **Next: Permissions**\.
+   1. For **Select your use case**, choose **Elastic Container Service Task**, **Next: Permissions**\.
 
    1. On the **Attached permissions policy** page, choose **AmazonEC2ContainerServiceFullAccess**, **Next: Review**\.
 


### PR DESCRIPTION
Role is still named "EC2ContainerService", so that was not updated.

*Description of changes:*
Updated service name from `EC2 Container Service` to `Elastic Container Service`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
