### PR TITLE
Made Example Task Definition use valid values

### DIFF
--- a/doc_source/Welcome.md
+++ b/doc_source/Welcome.md
@@ -50,8 +50,8 @@ The following is an example of a simple task definition containing a single cont
         "FARGATE"
     ],
     "networkMode": "awsvpc",
-    "memory": "100",
-    "cpu": "99",
+    "memory": "512",
+    "cpu": "256",
 }
 ```
 


### PR DESCRIPTION
*Description of changes:*

According to [Task Definition Parameters/Task Size](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size):

For `cpu`:

> If using the Fargate launch type, this field is required and you must use one of the following values, which determines your range of supported values for the memory parameter: 

* 256
* 512
* etc.

and for `memory`:

> If using the Fargate launch type, this field is required and you must use one of the following values, which determines your range of supported values for the cpu parameter: 

* 512
* 1024
* etc.

The example uses the `FARGATE` launch type, so it cannot use 100 and 99 for memory and cpu, respectively.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
