### PR TITLE
Avoid error when source version not present

### DIFF
--- a/doc_source/ecs-cd-pipeline.md
+++ b/doc_source/ecs-cd-pipeline.md
@@ -37,7 +37,8 @@ phases:
       - aws --version
       - $(aws ecr get-login --region $AWS_DEFAULT_REGION --no-include-email)
       - REPOSITORY_URI=012345678910.dkr.ecr.us-west-2.amazonaws.com/hello-world
-      - IMAGE_TAG=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
+      - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
+      - IMAGE_TAG=${COMMIT_HASH:=latest}
   build:
     commands:
       - echo Build started on `date`


### PR DESCRIPTION
Fallback mechanism to avoid getting error when CODEBUILD_RESOLVED_SOURCE_VERSION not present.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
