### PR TITLE
Update TaskDefinition - CMD description

### DIFF
--- a/doc_source/task_definition_parameters.md
+++ b/doc_source/task_definition_parameters.md
@@ -232,7 +232,7 @@ The entry point that is passed to the container\. This parameter maps to `Entryp
 `command`  
 Type: string array  
 Required: no  
-The command that is passed to the container\. This parameter maps to `Cmd` in the [Create a container](https://docs.docker.com/engine/api/v1.35/#operation/ContainerCreate) section of the [Docker Remote API](https://docs.docker.com/engine/api/v1.35/) and the `COMMAND` parameter to [https://docs.docker.com/engine/reference/commandline/run/](https://docs.docker.com/engine/reference/commandline/run/)\. For more information about the Docker `CMD` parameter, go to [https://docs\.docker\.com/engine/reference/builder/\#cmd](https://docs.docker.com/engine/reference/builder/#cmd)\.   
+The command that is passed to the container\. This parameter maps to `Cmd` in the [Create a container](https://docs.docker.com/engine/api/v1.35/#operation/ContainerCreate) section of the [Docker Remote API](https://docs.docker.com/engine/api/v1.35/) and the `COMMAND` parameter to [https://docs.docker.com/engine/reference/commandline/run/](https://docs.docker.com/engine/reference/commandline/run/)\. For more information about the Docker `CMD` parameter, go to [https://docs\.docker\.com/engine/reference/builder/\#cmd](https://docs.docker.com/engine/reference/builder/#cmd)\. If there are multiple arguments, each argument should be a separated string in the array.
 
 ```
 "command": ["string", ...]


### PR DESCRIPTION
Environment - CMD description is not clear in terms of breaking arguments into separated string in an array.
For example, people may try with this:
```
"command": [
  ["/usr/bin/java -Dserver.port=8081 -jar service.jar"]
]
```
The correct way should be: 
```
"command": [
  "/usr/bin/java", "-Dserver.port=8081", "-jar", "service.jar"
]
```

*Description of changes:* I have added a line to clarify this.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
