### PR TITLE
Fixed typo

### DIFF
--- a/doc_source/specifying-sensitive-data.md
+++ b/doc_source/specifying-sensitive-data.md
@@ -82,7 +82,7 @@ If you are referencing an AWS Secrets Manager secret in your parameter, the para
 
 1. For **Type**, choose **String**, **StringList**, or **SecureString**\.
 **Note**  
-If you choose **SecureString**, the **KMS Key ID** field appears\. If you don't provide a KMS CMK ID, a KMS CMK ARN, an alias name, or an alias ARN, then the system uses `alias/aws/ssm`, which is the default KMS CMK for Systems Manager\. To avoid using this key, tchoose a custom key\. For more information, see [Use Secure String Parameters](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-about.html) in the *AWS Systems Manager User Guide*\.
+If you choose **SecureString**, the **KMS Key ID** field appears\. If you don't provide a KMS CMK ID, a KMS CMK ARN, an alias name, or an alias ARN, then the system uses `alias/aws/ssm`, which is the default KMS CMK for Systems Manager\. To avoid using this key, choose a custom key\. For more information, see [Use Secure String Parameters](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-about.html) in the *AWS Systems Manager User Guide*\.
 When you create a secure string parameter in the console by using the `key-id` parameter with either a custom KMS CMK alias name or an alias ARN, you must specify the prefix `alias/` before the alias\. The following is an ARN example:  
 
      ```


### PR DESCRIPTION
Fixed typo 'tchoose' to 'choose'

*Issue #, if available:*

*Description of changes:*
There is a typo in the doc with 'tchoose'. It should be 'choose'.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
