### PR TITLE
Fix `&lt;&lt;` in User data example of the page `Launching an Amazon ECS Container Instance`.

### DIFF
--- a/doc_source/launch_container_instance.md
+++ b/doc_source/launch_container_instance.md
@@ -73,7 +73,7 @@ For more information about this configuration, see [Storing Container Instance C
 
         ```
         #!/bin/bash
-        cat &lt;&lt;'EOF' >> /etc/ecs/ecs.config
+        cat <<'EOF' >> /etc/ecs/ecs.config
         ECS_CLUSTER=your_cluster_name
         ECS_CONTAINER_INSTANCE_TAGS={"tag_key": "tag_value"}
         EOF


### PR DESCRIPTION
One example shows `cat &lt;&lt;'EOF' >> /etc/ecs/ecs.config` which should be `cat <<'EOF' >> /etc/ecs/ecs.config`. Fix it to avoid reader miss configuration.

*Issue #, if available:*
#60 

*Description of changes:*
One example shows `cat &lt;&lt;'EOF' >> /etc/ecs/ecs.config` which should be `cat <<'EOF' >> /etc/ecs/ecs.config` in the page `Launching an Amazon ECS Container Instance`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
