### PR TITLE
Update AWS_Fargate.md

### DIFF
--- a/doc_source/AWS_Fargate.md
+++ b/doc_source/AWS_Fargate.md
@@ -215,7 +215,7 @@ To use private registry authentication, you create a secret with AWS Secrets Man
             {
                 "image": "private-repo/private-image",
                 "repositoryCredentials": {
-                “credentialsParameter”: "aws:ssm:region:aws_account_id:secret:secret_name"
+                “credentialsParameter”: "aws:secretsmanager:region:aws_account_id:secret:secret_name"
                 }
             }
 ]


### PR DESCRIPTION
Private Registry Authentication for Tasks section used AWS Systems Manager ARN instead of AWS Secrets Manager ARN as supported by Amazon ECS (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/private-auth.html)

*Issue #, if available:*

*Description of changes:*
Updated the example to use AWS Secrets Manager ARN.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
