### PR TITLE
Fix placement of the enableECSManagedTags parameter definition

### DIFF
--- a/doc_source/service_definition_parameters.md
+++ b/doc_source/service_definition_parameters.md
@@ -194,13 +194,13 @@ The external deployment type enables you to use any third party deployment contr
 
 `tags`  
 The metadata that you apply to the service to help you categorize and organize them\. Each tag consists of a key and an optional value, both of which you define\. When a service is deleted, the tags are deleted as well\. Tag keys can have a maximum character length of 128 characters, and tag values can have a maximum length of 256 characters\. For more information, see [Tagging Your Amazon ECS Resources](ecs-using-tags.md)\.
-
-`enableECSManagedTags`  
-Specifies whether to enable Amazon ECS managed tags for the tasks in the service\. For more information, see [Tagging Your Resources for Billing](ecs-using-tags.md#tag-resources-for-billing)\.    
 `key`  
 One part of a key\-value pair that make up a tag\. A key is a general label that acts like a category for more specific tag values\.  
 `value`  
 The optional part of a key\-value pair that make up a tag\. A value acts as a descriptor within a tag category \(key\)\.
+
+`enableECSManagedTags`  
+Specifies whether to enable Amazon ECS managed tags for the tasks in the service\. For more information, see [Tagging Your Resources for Billing](ecs-using-tags.md#tag-resources-for-billing)\.
 
 `propagateTags`  
 Specifies whether to copy the tags from the task definition or the service to the tasks in the service\. If no value is specified, the tags are not copied\. Tags can only be copied to the tasks within the service during service creation\. To add tags to a task after service creation, use the `TagResource` API action\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The `enableECSManagedTags` property was located between the`tags` property and the sub-properties of `tags` when it's not a sub-property of `tags`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
