### PR TITLE
Fixed broken IIS task definition due to entrypoint changes

### DIFF
--- a/doc_source/ECS_Windows_getting_started.md
+++ b/doc_source/ECS_Windows_getting_started.md
@@ -135,7 +135,7 @@ The Fargate launch type is not compatible with Windows containers\.
          "image": "microsoft/iis",
          "cpu": 512,
          "entryPoint":["powershell", "-Command"],
-         "command":["New-Item -Path C:\\inetpub\\wwwroot\\index.html -ItemType file -Value '<html> <head> <title>Amazon ECS Sample App</title> <style>body {margin-top: 40px; background-color: #333;} </style> </head><body> <div style=color:white;text-align:center> <h1>Amazon ECS Sample App</h1> <h2>Congratulations!</h2> <p>Your application is now running on a container in Amazon ECS.</p>' --Force"],
+         "command":["New-Item -Path C:\\inetpub\\wwwroot\\index.html -ItemType file -Value '<html> <head> <title>Amazon ECS Sample App</title> <style>body {margin-top: 40px; background-color: #333;} </style> </head><body> <div style=color:white;text-align:center> <h1>Amazon ECS Sample App</h1> <h2>Congratulations!</h2> <p>Your application is now running on a container in Amazon ECS.</p>' -Force ; C:\\ServiceMonitor.exe w3svc"],
          "portMappings": [
            {
              "protocol": "tcp",


### PR DESCRIPTION
*Description of changes:*

Microsoft IIS Docker image has changed the entrypoint to: `C:\ServiceMonitor.exe w3svc` to keep the container running. With the current task definition, the container will exit in a few seconds. Adding ServiceMonitor.exe after modifying the index.html file fixes the problem and keep container running. More information about ServiceMonitor can be found at: 
[https://github.com/microsoft/IIS.ServiceMonitor](https://github.com/microsoft/IIS.ServiceMonitor)

The idea of adding `C:\ServiceMonitor.exe w3svc` is based on [https://github.com/microsoft/iis-docker/blob/master/windowsservercore-1903/Dockerfile](https://github.com/microsoft/iis-docker/blob/master/windowsservercore-1903/Dockerfile)

Also fix the syntax error --Force should be -Force (single dash).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
