### PR TITLE
Fixes issue #72

### DIFF
--- a/doc_source/ecs-using-tags.md
+++ b/doc_source/ecs-using-tags.md
@@ -59,7 +59,7 @@ The following basic restrictions apply to tags:
 + Maximum value length – 256 Unicode characters in UTF\-8
 + If your tagging schema is used across multiple services and resources, remember that other services may have restrictions on allowed characters\. Generally allowed characters are: letters, numbers, and spaces representable in UTF\-8, and the following characters: \+ \- = \. \_ : / @\.
 + Tag keys and values are case\-sensitive\.
-+ Don't use the `aws:` prefix for either keys or values; it's reserved for AWS use\. You can't edit or delete tag keys or values with this prefix\. Tags with this prefix do not count against your tags per resource limit\.
++ Don't use the `aws:` (or `AWS:` or any upper/lower case combination) prefix for either keys or values; it's reserved for AWS use\. You can't edit or delete tag keys or values with this prefix\. Tags with this prefix do not count against your tags per resource limit\.
 
 ## Tagging Your Resources for Billing<a name="tag-resources-for-billing"></a>
 


### PR DESCRIPTION
tags containing the AWS: or Aws: (upper/lower case) prefixes are not allowed as well

*Issue #, if available:*
Fixes issue #72
*Description of changes:*
Changes wording around tags restrictions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
