### PR TITLE
docs: correct config output

### DIFF
--- a/doc_source/cmd-ecs-cli-configure.md
+++ b/doc_source/cmd-ecs-cli-configure.md
@@ -54,10 +54,10 @@ Contents of the `~/.ecs/config` file after running the command:
 
 ```
 version: v1
-default: fargate
+default: ecs-cli-demo
 clusters:
   ecs-cli-demo:
     cluster: ecs-cli-demo
     region: us-east-1
-    default_launch_type: "FARGATE"
+    default_launch_type: FARGATE
 ```


### PR DESCRIPTION
The current version of `ecs-cli` (1.14.1) produces the updated output.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
