### PR TITLE
Added --cluster flag to ecs-cli up

### DIFF
--- a/doc_source/ecs-cli-tutorial-fargate.md
+++ b/doc_source/ecs-cli-tutorial-fargate.md
@@ -72,7 +72,7 @@ If this is the first time that you are configuring the Amazon ECS CLI, these con
 1. Create an Amazon ECS cluster with the ecs\-cli up command\. Because you specified Fargate as your default launch type in the cluster configuration, this command creates an empty cluster and a VPC configured with two public subnets\.
 
    ```
-   ecs-cli up
+   ecs-cli up --cluster tutorial
    ```
 **Note**  
 This command may take a few minutes to complete as your resources are created\. Take note of the VPC and subnet IDs that are created as they are used later\.


### PR DESCRIPTION

*Description of changes:*

Running just `ecs-cli up` won't work for users who previously created a different cluster with ecs-cli. Adding the `--cluster` flag will make this tutorial work for everyone without needing to modify the example code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
