### PR TITLE
Remove unclear paragraph about IAM role requisites

### DIFF
--- a/doc_source/task_IAM_role.md
+++ b/doc_source/task_IAM_role.md
@@ -1,7 +1,5 @@
 # **Amazon ECS Task Role**<a name="task_IAM_role"></a>
 
-Before you can use IAM roles for tasks, Amazon ECS needs permission to make calls to the AWS APIs on your behalf\. These permissions are provided by the Amazon ECS Task Role\.
-
 You can create a task IAM role for each task definition that needs permission to call AWS APIs\. You simply create an IAM policy that defines which permissions your task should have, and then attach that policy to a role that uses the Amazon ECS Task Role trust relationship policy\. For more information, see [Creating an IAM Role and Policy for your Tasks](task-iam-roles.md#create_task_iam_policy_and_role)\. 
 
 The Amazon ECS Task Role trust relationship is shown below\.


### PR DESCRIPTION
Fixes issue #87

The paragraph: "Before you can use IAM roles for tasks, Amazon ECS needs permission to make calls to the AWS APIs on your behalf. These permissions are provided by the Amazon ECS Task Role." is unclear and removing it won't make a difference.

These permissions are either provided by the trust policy for "ecs-task.amazonaws.com" or something else.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
