### PR TITLE
requirement of iam:PassRole for task role - CWE_IAM_role.md

### DIFF
--- a/doc_source/CWE_IAM_role.md
+++ b/doc_source/CWE_IAM_role.md
@@ -23,7 +23,7 @@ The `AmazonEC2ContainerServiceEventsRole` policy is shown below\.
 }
 ```
 
-If your scheduled tasks require the use of the task execution role or a task role override, then you must add `iam:PassRole` permissions for each task execution role or task role override to the CloudWatch Events IAM role\. For more information about the task execution role, see [Amazon ECS Task Execution IAM Role](task_execution_IAM_role.md)\.
+If your scheduled tasks require the use of the task execution role, task role or a task role override, then you must add `iam:PassRole` permissions for each task execution role, task role or task role override to the CloudWatch Events IAM role\. For more information about the task execution role, see [Amazon ECS Task Execution IAM Role](task_execution_IAM_role.md)\.
 
 **Note**  
 Specify the full ARN of your task execution role or task role override\.


### PR DESCRIPTION
In CloudWatch IAM role - iam:PassRole permission are also required for task role.
Changes in addition to https://github.com/awsdocs/amazon-ecs-developer-guide/blob/master/doc_source/scheduled_tasks.md

*Issue #, if available:*

*Description of changes:*
adding requirement of iam:PassRole permission if task definition has task role specified.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
