### PR TITLE
Ecs agent restart after upgrade

### DIFF
--- a/doc_source/agent-update-ecs-ami.md
+++ b/doc_source/agent-update-ecs-ami.md
@@ -31,10 +31,12 @@ Amazon ECS\-optimized Amazon Linux AMI:
      ```
 If you are still showing the older version running after this, then you can either restart the instance, or run the following commands on your instance:  
 Amazon ECS\-optimized Amazon Linux 2 AMI:  
+
      ```
      sudo systemctl restart ecs
      ```
 Amazon ECS\-optimized Amazon Linux AMI:  
+
      ```
      sudo service ecs restart
      ```

--- a/doc_source/agent-update-ecs-ami.md
+++ b/doc_source/agent-update-ecs-ami.md
@@ -29,6 +29,15 @@ Amazon ECS\-optimized Amazon Linux AMI:
      ```
      sudo service docker restart && sudo start ecs
      ```
+If you are still showing the older version running after this, then you can either restart the instance, or run the following commands on your instance:  
+Amazon ECS\-optimized Amazon Linux 2 AMI:  
+     ```
+     sudo systemctl restart ecs
+     ```
+Amazon ECS\-optimized Amazon Linux AMI:  
+     ```
+     sudo service ecs restart
+     ```
 
 ## Updating the Amazon ECS Container Agent with the `UpdateContainerAgent` API Operation<a name="agent-update-api"></a>
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I have found at least one instance where the agent needs to be restarted manually after updating the package. It would be useful to have instructions about how to do this here.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
