### PR TITLE
Remove reference to "CodeDeploy"

### DIFF
--- a/doc_source/ecs-cd-pipeline.md
+++ b/doc_source/ecs-cd-pipeline.md
@@ -25,7 +25,7 @@ This tutorial uses CodeBuild to build your Docker image and push the image to Am
   + Build the Docker image and tag the image both as `latest` and with the Git commit ID\.
 + Post\-build stage:
   + Push the image to your ECR repository with both tags\.
-  + Write a file called `imagedefinitions.json` in the build root that has your Amazon ECS service's container name and the image and tag\. The deployment stage of your CD pipeline uses this information to create a new revision of your service's task definition, and then it updates the service to use the new task definition\. The `imagedefinitions.json` file is required for the CodeDeploy ECS job worker\.
+  + Write a file called `imagedefinitions.json` in the build root that has your Amazon ECS service's container name and the image and tag\. The deployment stage of your CD pipeline uses this information to create a new revision of your service's task definition, and then it updates the service to use the new task definition\. The `imagedefinitions.json` file is required for the ECS job worker\.
 
 ```
 version: 0.2


### PR DESCRIPTION
The line I am editing is 
>> The `imagedefinitions.json` file is required for the CodeDeploy ECS job worker\.

To:

 The `imagedefinitions.json` file is required for the ECS job worker\.

CodeDeploy ECS job worker is for Blue/Green deployment not the standard one. The CodeDeploy ECS job worker needs file "imageDetail.json" for Amazon ECS Blue/Green Deployment Actions and not "imagedefinitions.json". When you mention the word CodeDeploy in this tutorial, it causes confusion that this is a Blue/Green deployment which this is not.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
