### PR TITLE
fix: docker image tag

### DIFF
--- a/doc_source/ecs-cd-pipeline.md
+++ b/doc_source/ecs-cd-pipeline.md
@@ -66,7 +66,7 @@ The build specification was written for the following task definition, used by t
     "containerDefinitions": [
       {
         "name": "hello-world",
-        "image": "012345678910.dkr.ecr.us-west-2.amazonaws.com/hello-world:6a57b99",
+        "image": "012345678910.dkr.ecr.us-west-2.amazonaws.com/hello-world:latest",
         "cpu": 100,
         "portMappings": [
           {


### PR DESCRIPTION
This tag is specific to the sample app that was used in this tutorial. It is unclear for those who follow the tutorial, that the tag needs to be changed as well. Using `latest` abstracts away this issue.