### PR TITLE
updated healthCheckGracePeriodSeconds

### DIFF
--- a/doc_source/service_definition_parameters.md
+++ b/doc_source/service_definition_parameters.md
@@ -175,7 +175,7 @@ The security groups associated with the task or service\. If you do not specify 
 Whether the task's elastic network interface receives a public IP address\.
 
 `healthCheckGracePeriodSeconds`  
-The period of time, in seconds, that the Amazon ECS service scheduler should ignore unhealthy Elastic Load Balancing target health checks, container health checks, and Route 53 health checks after a task has first started\. This is only valid if your service is configured to use a load balancer\. If your service's tasks take a while to start and respond to health checks, you can specify a health check grace period of up to 2,147,483,647 seconds during which the ECS service scheduler ignores the health check status\. This grace period can prevent the ECS service scheduler from marking tasks as unhealthy and stopping them before they have time to come up\.
+The period of time, in seconds, that the Amazon ECS service scheduler should ignore unhealthy Elastic Load Balancing target health checks, container health checks, and Route 53 health checks after a task enters the RUNNING state\. This is only valid if your service is configured to use a load balancer\. If your service's tasks take a while to start and respond to health checks, you can specify a health check grace period of up to 2,147,483,647 seconds during which the ECS service scheduler ignores the health check status\. This grace period can prevent the ECS service scheduler from marking tasks as unhealthy and stopping them before they have time to come up\.
 
 `schedulingStrategy`  
 The scheduling strategy to use\. For more information, see [Service Scheduler Concepts](ecs_services.md#service_scheduler)\.  


### PR DESCRIPTION
Updated the healthCheckGracePeriodSeconds to be more explicit as to when the timing begins. 

Updated the working to "after a task enters the RUNNING state"

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
