### PR TITLE
Placed a link to SQS tutorial

### DIFF
--- a/doc_source/ECS-AMI-SubscribeTopic.md
+++ b/doc_source/ECS-AMI-SubscribeTopic.md
@@ -5,7 +5,7 @@ The Amazon ECS\-optimized Amazon Linux AMI receives regular updates for agent ch
 **Note**  
 Your user account must have `sns::subscribe` IAM permissions to subscribe to an SNS topic\.
 
-You can subscribe an Amazon SQS queue to this notification topic, but you must use a topic ARN that is in the same region\. For more information, see [Tutorial: Subscribing an Amazon SQS Queue to an Amazon SNS Topic]() in the *Amazon Simple Queue Service Developer Guide*\.
+You can subscribe an Amazon SQS queue to this notification topic, but you must use a topic ARN that is in the same region\. For more information, see [Tutorial: Subscribing an Amazon SQS Queue to an Amazon SNS Topic](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-subscribe-queue-sns-topic.html) in the *Amazon Simple Queue Service Developer Guide*\.
 
 You can also use an AWS Lambda function to trigger events when notifications are received\. For more information, see [Invoking Lambda functions using Amazon SNS notifications](https://docs.aws.amazon.com/sns/latest/dg/sns-lambda.html) in the *Amazon Simple Notification Service Developer Guide*\.
 


### PR DESCRIPTION
*Issue 103:*
Link to "Tutorial: Subscribing an Amazon SQS Queue to an Amazon SNS Topic" in the third paragraph did not point to the SQS tutorial.

*Description of changes:*
Placed the link to the SQS tutorial.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
