### PR TITLE
Fix incorrect and outdated CodeBuild instructions

### DIFF
--- a/doc_source/ecs-cd-pipeline.md
+++ b/doc_source/ecs-cd-pipeline.md
@@ -31,6 +31,9 @@ This tutorial uses CodeBuild to build your Docker image and push the image to Am
 version: 0.2
 
 phases:
+  install:
+    runtime-versions:
+      docker: 18
   pre_build:
     commands:
       - echo Logging in to Amazon ECR...
@@ -133,17 +136,15 @@ Use the CodePipeline wizard to create your pipeline stages and connect your sour
 
    1. For **Project name**, choose a unique name for your build project\. For this tutorial, the project name is **hello\-world**\.
 
-   1. For **Environment image**, choose **Custom image**\.
+   1. For **Environment image**, choose **Managed image**\.
 
-   1. For **Environment type**, choose **Linux**\.
+   1. For **Operating system**, choose **Amazon Linux 2**\.
 
-   1. For **Image registry**, choose **Amazon ECR**\.
+   1. For **Runtime(s)**, choose **Standard**\.
 
-   1. For **ECR account**, choose **My ECR account**\.
+   1. For **Image**, choose **aws/codebuild/amazonlinux2-x86_64-standard:2.0**\.
 
-   1. For **Amazon ECR repository**, select the repository you pushed your image to\.
-
-   1. For **Amazon ECR image**, select your image\.
+   1. Use the default values for **Image version** and **Environment type**\.
 
    1. Select **Enable this flag if you want to build Docker images or want your builds to get elevated privileges**\.
 


### PR DESCRIPTION
*Description of changes:*
The current documentation provides incorrect instructions on Step2 -> Item 5 -> Items b-g. It instructs the user to use the image that will be built in CodeBuild as the build image itself, which most of the time will not work since this is will be the application image to be deployed in ECS. Instead of that, we should use one of the standard CodeBuild images, which provides the utilities necessary to build Docker images.

The changes in this pull request change the instructions to guide users to use the standard Amazon Linux 2 docker image as the build image, and adds additional buildspec code to support that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
