### PR TITLE
Add comment for Fargate capacity provider provisioning

### DIFF
--- a/doc_source/fargate-capacity-providers.md
+++ b/doc_source/fargate-capacity-providers.md
@@ -20,6 +20,7 @@ The following should be considered when using Fargate capacity providers\.
 + Using Fargate Spot requires that your task use platform version 1\.3\.0 or later\. For more information, see [AWS Fargate Platform Versions](platform_versions.md)\.
 + When tasks using the Fargate and Fargate Spot capacity providers are stopped, a task state change event is sent to Amazon EventBridge\. The stopped reason describes the cause\. For more information, see [Task State Change Events](ecs_cwe_events.md#ecs_task_events)\.
 + A cluster may contain a mix of Fargate and Auto Scaling group capacity providers, however a capacity provider strategy may only contain either Fargate or Auto Scaling group capacity providers, but not both\. For more information, see [Auto Scaling Group Capacity Providers](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-auto-scaling.html#asg-capacity-providers) in the *Amazon Elastic Container Service Developer Guide*\.
++ Fargate and Fargate Spot capacity providers are independent. AWS Fargate will follow each strategy to launch your Fargate tasks until it successfully being provision. The price model of the tasks will follow the strategy it owns.
 
 ## Handling Fargate Spot Termination Notices<a name="fargate-capacity-providers-termination"></a>
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

**Please correct me if I am wrong:** As far as I know, the capacity provider determine the infrastructure to use for tasks and it doesn't have any action like using priority to decide which strategy should use first. Instead, it is using `weight` to distribute how does these tasks and ECS will follow them.

Based on this point, I would recommend the document can add more comment to explain Fargate and Fargate Spot capacity provider are independent. Fargate on-demand won't be replaced by Fargate Spot if there has any reason unable to launch Spot tasks.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
