### PR TITLE
create-blue-green.md: Fix typo

### DIFF
--- a/doc_source/create-blue-green.md
+++ b/doc_source/create-blue-green.md
@@ -230,7 +230,7 @@ Use the following steps to create your CodeDeploy application, the Application L
 
    ```
    {
-      "applicationName": "tutorial-bluegreen=app",
+      "applicationName": "tutorial-bluegreen-app",
       "autoRollbackConfiguration": {
          "enabled": true,
          "events": [ "DEPLOYMENT_FAILURE" ]


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Fix typo in the sample file for the `aws deploy create-deployment-group` command.

The default named used in the previous command when creating the CodeDeploy application is `tutorial-bluegreen-app`.
This commit changes the incorrect `=` to `-`.
This allows customers to easily copy/paste these commands and json files.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.