### PR TITLE
create-blue-green.md: Fix get-deployment-target

### DIFF
--- a/doc_source/create-blue-green.md
+++ b/doc_source/create-blue-green.md
@@ -370,7 +370,7 @@ Use the following steps to create and upload an application specification file \
       ```
       aws deploy get-deployment-target \
            --deployment-id "d-IMJU3A8TW" \
-           --target-id tutorial-bluegreen-app:service-bluegreen \
+           --target-id tutorial-bluegreen-cluster:service-bluegreen \
            --region us-east-1
       ```
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Update the default command for `aws deploy get-deployment-target` to work with the default values used previously.

The API error message explains what the format of the `--target-id` argument should be:

```
An error occurred (InvalidDeploymentTargetIdException) when calling the GetDeploymentTarget operation: Invalid id tutorial-bluegreen-cluster for ECS deployment, valid Id should be in format <cluster-name>:<service-name>
```

And in this example, the default value for `<cluster-name>` is `tutorial-bluegreen-cluster`, not `tutorial-bluegreen-app` (which is the name of the CodeDeploy application.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
