### PR TITLE
added description and fix for LOCATION error.

### DIFF
--- a/doc_source/api_failures_messages.md
+++ b/doc_source/api_failures_messages.md
@@ -22,6 +22,9 @@ The resource or resources requested by the task are unavailable on the given con
 The number of GPUs requested by the task are unavailable on the given container instance\. You may need to add GPU\-enabled container instances to your cluster\. For more information, see [Working with GPUs on Amazon ECS](ecs-gpu.md)\.  
 `AGENT` \(container instance ID\)  
 The container instance that you attempted to launch a task onto has an agent that is currently disconnected\. To prevent extended wait times for task placement, the request was rejected\.  
+`LOCATION` \(container instance ID\)  
+The container instance onto which you attempted to launch a task is in a different availability zone than the availability zone of the subnet which is specified in subnets section of [awsvpcConfiguration](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_AwsVpcConfiguration.html) of task with [`awsvpc` as network mode](task-networking.md)\. 
+To prevent this error, you can either specify the same subnets in the awsvpcConfiguration as that of your container instance or you can specify subnets from multiple availability zones, So that the one in which your container instance is present gets selected automatically\.  
 `ATTRIBUTE` \(container instance ID\)  
 Your task definition contains a parameter that requires a specific container instance attribute that is not available on your container instances\. For example, if your task uses the `awsvpc` network mode, but there are no instances in your specified subnets with the `ecs.capability.task-eni` attribute\. For more information about which attributes are required for specific task definition parameters and agent configuration variables, see [Task Definition Parameters](task_definition_parameters.md) and [Amazon ECS Container Agent Configuration](ecs-agent-config.md)\.
 + `StartTask`  


### PR DESCRIPTION
RunTask fails with LOCATION error when there is a mismatch AZ of instance and awsvpcConfiguration.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
