### PR TITLE
Update Windows ECS CLI installation commands

### DIFF
--- a/doc_source/ECS_CLI_installation.md
+++ b/doc_source/ECS_CLI_installation.md
@@ -20,8 +20,8 @@ Download the Amazon ECS CLI binary\.
   Open Windows PowerShell and run the following commands:
 
   ```
-  PS C:\> New-Item ‘C:\Program Files\Amazon\ECSCLI’ -type directory
-  PS C:\> Invoke-WebRequest -OutFile ‘C:\Program Files\Amazon\ECSCLI\ecs-cli.exe’ https://amazon-ecs-cli.s3.amazonaws.com/ecs-cli-windows-amd64-latest.exe
+  PS C:\> New-Item -Path 'C:\Program Files\Amazon\ECSCLI' -ItemType Directory
+  PS C:\> Invoke-WebRequest -OutFile 'C:\Program Files\Amazon\ECSCLI\ecs-cli.exe' https://amazon-ecs-cli.s3.amazonaws.com/ecs-cli-windows-amd64-latest.exe
   ```
 **Note**  
 If you encounter permissions issues, ensure that you are running PowerShell as an administrator\.


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

Update the Windows ECS CLI installation command, which currently fails due to bad quoting.

**Before:**
```PowerShell
PS > New-Item ‘C:\Program Files\Amazon\ECSCLI’ -type directory
New-Item: A positional parameter cannot be found that accepts argument 'Files\Amazon\ECSCLI'.
```

**After:**
```PowerShell
PS > New-Item -Path 'C:\Program Files\Amazon\ECSCLI' -ItemType Directory


    Directory: C:\Program Files\Amazon

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
d----          2020-03-21  4:36 PM                ECSCLI
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.