### PR TITLE
Fix typos in the example efsVolumeConfiguration 

### DIFF
--- a/doc_source/efs-volumes.md
+++ b/doc_source/efs-volumes.md
@@ -53,8 +53,8 @@ In order to use Amazon EFS file system volumes for your containers, you must spe
             "efsVolumeConfiguration": {
                 "fileSystemId": "fs-1234",
                 "rootDirectory": "/path/to/my/data",
-                "tranitEncryption": "ENABLED",
-                "transitEncryptionPort: {
+                "transitEncryption": "ENABLED",
+                "authorizationConfig": {
                     "accessPointId": "fsap-1234",
                     "iam": "ENABLED"
                 }


### PR DESCRIPTION
There's a missing s in tranitEncryption param name. Moreover, the transitEncryptionPort was used instead of authorizationConfig :wink: