### PR TITLE
JSON block incorrect for authorizationConfig

### DIFF
--- a/doc_source/efs-volumes.md
+++ b/doc_source/efs-volumes.md
@@ -54,7 +54,7 @@ In order to use Amazon EFS file system volumes for your containers, you must spe
                 "fileSystemId": "fs-1234",
                 "rootDirectory": "/path/to/my/data",
                 "tranitEncryption": "ENABLED",
-                "transitEncryptionPort: {
+                "authorizationConfig: {
                     "accessPointId": "fsap-1234",
                     "iam": "ENABLED"
                 }


### PR DESCRIPTION
JSON block incorrectly shows transitEncryptionPort when the block should be authorizationConfig according to documentation.

*Issue #, if available:*

*Description of changes:*
Updated the JSON according to the wording of the documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
