### PR TITLE
removing "host": {} from volume.

### DIFF
--- a/doc_source/fargate-task-storage.md
+++ b/doc_source/fargate-task-storage.md
@@ -17,8 +17,7 @@ In this example, you may have two database containers that need to access the sa
    ```
      "volumes": [
        {
-         "name": "database_scratch",
-         "host": {}
+         "name": "database_scratch"
        }
      ]
    ```


### PR DESCRIPTION


*Issue #, if available:*
The `host` and `sourcePath` parameters are not supported for Fargate tasks.
      "host": {} > translates to null, will have same behaviour as not mentioning at all.
best would to remove to avoid any ambiguity.

API Reference: https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_HostVolumeProperties.html

*Description of changes:*

removed "host": {} from volume.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
