### PR TITLE
Fix cross documentation reference

### DIFF
--- a/doc_source/bootstrap_container_instance.md
+++ b/doc_source/bootstrap_container_instance.md
@@ -4,7 +4,7 @@ When you launch an Amazon ECS container instance, you have the option of passing
 
 You can pass multiple types of user data to Amazon EC2, including cloud boothooks, shell scripts, and `cloud-init` directives\. For more information about these and other format types, see the [Cloud\-Init documentation](https://cloudinit.readthedocs.io/en/latest/topics/format.html)\. 
 
-You can pass this user data into the Amazon EC2 launch wizard in [Step 7](launch_container_instance.md#instance-launch-user-data-step) of [Launching an Amazon ECS Container Instance](launch_container_instance.md)\. 
+You can pass this user data into the Amazon EC2 launch wizard in [Step 6, item vii](launch_container_instance.md#instance-launch-user-data-step) of [Launching an Amazon ECS Container Instance](launch_container_instance.md)\. 
 
 **Topics**
 + [Amazon ECS Container Agent](#bootstrap_container_agent)


### PR DESCRIPTION
The reference was pointing to item 7, but the target documentation was updated. To avoid confusing the customer, the new destination position should be used.

*Description of changes:*
Updated the cross documentation reference.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
