### PR TITLE
Update ENI trunking unsupported instance type

### DIFF
--- a/doc_source/container-instance-eni.md
+++ b/doc_source/container-instance-eni.md
@@ -129,7 +129,7 @@ Each container instance has a default network interface, referred to as a trunk 
 The following shows the supported Amazon EC2 instance types and how many tasks using the `awsvpc` network mode can be launched on each instance type before and after opting in to the `awsvpcTrunking` account setting\. For the elastic network interface \(ENI\) limits on each instance type, add one to the current task limit, as the primary network interface counts against the limit, and add two to the new task limit, as both the primary network interface and the trunk network instance count again the limit\.
 
 **Important**  
-The `c5n`, `m5n`, `m5dn`, `r5n`, and `r5dn` instance types are not supported\.
+The `t2`, `t3`, `c5n`, `m5n`, `m5dn`, `r5n`, and `r5dn` instance types are not supported\.
 
 
 | Instance Type | Current Task Limit per Instance | New Task Limit per Instance | 


### PR DESCRIPTION
*Issue #, if available: #125
*Description of changes:

According to the member in AWS container road map mention, due to technical constraints with how ENI trunking works, ENI trunking do not currently have pans to support t2 and t3.

Add it to unsupported notice, make it more clear to customer:
The `t2`, `t3`, `c5n`, `m5n`, `m5dn`, `r5n`, and `r5dn` instance types are not supported

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
