### PR TITLE
Removed Note for Same port on UDP and TCP

### DIFF
--- a/doc_source/task_definition_parameters.md
+++ b/doc_source/task_definition_parameters.md
@@ -116,8 +116,7 @@ Type: integer
 Required: yes, when `portMappings` are used  
 The port number on the container that is bound to the user\-specified or automatically assigned host port\.  
 If using containers in a task with the Fargate launch type, exposed ports should be specified using `containerPort`\.  
-If using containers in a task with the EC2 launch type and you specify a container port and not a host port, your container automatically receives a host port in the ephemeral port range\. For more information, see `hostPort`\. Port mappings that are automatically assigned in this way do not count toward the 100 reserved ports limit of a container instance\.  
-You cannot expose the same container port for multiple protocols\. An error will be returned if this is attempted\.  
+If using containers in a task with the EC2 launch type and you specify a container port and not a host port, your container automatically receives a host port in the ephemeral port range\. For more information, see `hostPort`\. Port mappings that are automatically assigned in this way do not count toward the 100 reserved ports limit of a container instance\.    
 `hostPort`  
 Type: integer  
 Required: no  


### PR DESCRIPTION
This is already supported by Fargate and ECS, no error will be returned.

*Issue #, if available:*

*Description of changes:* I have removed the note that states that an error will be thrown if a task definition is created on both TCP and UDP ports, as this is no longer true


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
