### PR TITLE
fixed cluster task metadata endpoint definition

### DIFF
--- a/doc_source/task-metadata-endpoint-v2.md
+++ b/doc_source/task-metadata-endpoint-v2.md
@@ -33,7 +33,7 @@ This endpoint returns Docker stats JSON for the specified Docker container ID\. 
 The following information is returned from the task metadata endpoint \(`169.254.170.2/v2/metadata`\) JSON response\.
 
 `Cluster`  
-The full Amazon Resource Name \(ARN\) of the Amazon ECS cluster to which the task belongs\.
+Returns the value of what is set on `ECS_CLUSTER` under the `/etc/ecs/ecs.config` file of the Container Instance where the task is running. For Fargate based tasks, the full Amazon Resource Name \(ARN\) of the Amazon ECS Cluster will always be returned\.
 
 `TaskARN`  
 The full Amazon Resource Name \(ARN\) of the task to which the container belongs\.

--- a/doc_source/task-metadata-endpoint-v3.md
+++ b/doc_source/task-metadata-endpoint-v3.md
@@ -32,7 +32,7 @@ This path returns Docker stats JSON for all of the containers associated with th
 The following information is returned from the task metadata endpoint \(`${ECS_CONTAINER_METADATA_URI}/task`\) JSON response\.
 
 `Cluster`  
-The full Amazon Resource Name \(ARN\) of the Amazon ECS cluster to which the task belongs\.
+Returns the value of what is set on `ECS_CLUSTER` under the `/etc/ecs/ecs.config` file of the Container Instance where the task is running. For Fargate based tasks, the full Amazon Resource Name \(ARN\) of the Amazon ECS Cluster will always be returned\.
 
 `TaskARN`  
 The full Amazon Resource Name \(ARN\) of the task to which the container belongs\.

--- a/doc_source/task-metadata-endpoint-v4.md
+++ b/doc_source/task-metadata-endpoint-v4.md
@@ -46,7 +46,7 @@ This path returns Docker stats JSON for all of the containers associated with th
 The following information is returned from the task metadata endpoint \(`${ECS_CONTAINER_METADATA_URI_V4}/task`\) JSON response\.
 
 `Cluster`  
-The full Amazon Resource Name \(ARN\) of the Amazon ECS cluster to which the task belongs\.
+Returns the value of what is set on `ECS_CLUSTER` under the `/etc/ecs/ecs.config` file of the Container Instance where the task is running. For Fargate based tasks, the full Amazon Resource Name \(ARN\) of the Amazon ECS Cluster will always be returned\.
 
 `TaskARN`  
 The full Amazon Resource Name \(ARN\) of the task to which the container belongs\.


### PR DESCRIPTION
*Issue #, if available:*
No issue
*Description of changes:*
Cluster definition was wrong as it only returns ARN if it is set on the ecs.config file, otherwise returns the cluster name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
