### PR TITLE
Add missing trailing quote to awsfirelens logDriver

### DIFF
--- a/doc_source/task_definition_parameters.md
+++ b/doc_source/task_definition_parameters.md
@@ -483,7 +483,7 @@ The following should be noted when specifying a log configuration for your conta
 ```  
 `logDriver`  
 Type: string  
-Valid values: `"awslogs","fluentd","gelf","json-file","journald","logentries","splunk","syslog","awsfirelens`  
+Valid values: `"awslogs","fluentd","gelf","json-file","journald","logentries","splunk","syslog","awsfirelens"`  
 Required: yes, when `logConfiguration` is used  
 The log driver to use for the container\. The valid values listed earlier are log drivers that the Amazon ECS container agent can communicate with by default\.  
 For tasks using the Fargate launch type, the supported log drivers are `awslogs`, `splunk`, and `awsfirelens`\.  


### PR DESCRIPTION
This is just a tiny formatting issue; all other log drivers have double quotes, so close the last one with it too.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
