### PR TITLE
Propose the correct task definition size limit

### DIFF
--- a/doc_source/service-quotas.md
+++ b/doc_source/service-quotas.md
@@ -20,7 +20,7 @@ Most of these service quotas, but not all, are listed under the Amazon Elastic C
 |  Tasks launched \(`count`\) per run\-task  |  The maximum number of tasks that can be launched per `RunTask` API action\.  |  10  |  No  | 
 |  Container instances per start\-task  |  The maximum number of container instances specified in a `StartTask` API action\.  |  10  |  No  | 
 |  Revisions per task definition family  |  The maximum number of revisions per task definition family\. Deregistering a task definition revision does not exclude it from being included in this limit\.  |  1,000,000  |  No  | 
-|  Task definition size limit  |  The maximum size, in KiB, of a task definition\.  |  32  |  No  | 
+|  Task definition size limit  |  The maximum size, in KiB, of a task definition\.  |  64  |  No  | 
 |  Task definition max containers  |  The maximum number of containers definitions within a task definition\.  |  10  |  No  | 
 |  Subnets specified in an `awsvpcConfiguration`  |  The maximum number of subnets specified within an `awsvpcConfiguration`\.  |  16  |  No  | 
 |  Security groups specified in an `awsvpcConfiguration`  |  The maximum number of security groups specified within an `awsvpcConfiguration`\.  |  5  |  No  | 


### PR DESCRIPTION
*Issue #, if available:*

According to my testing, I can create task definition over `32K`. I think the limit as mentioned on the doc should be corrected. When I tried to create a task definition over 64K, following error will appear:

```
Unable to create a new revision of Task Definition

Actual length: '66420'. Max allowed length is '65536' bytes.
```

CloudTrail event:

```
    "eventTime": "2021-01-21T16:24:09Z",
    "eventSource": "ecs.amazonaws.com",
    "eventName": "RegisterTaskDefinition",
    "awsRegion": "ap-northeast-1",
    "userAgent": "console.amazonaws.com",
    "errorCode": "ClientException",
    "errorMessage": "Actual length: '66420'. Max allowed length is '65536' bytes.",
    "requestParameters": null,
    "responseElements": null,
```

*Description of changes:*

**So help to update the task definition size limit, which should be allowed up to `65536' bytes (64KiB)`.**

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
