### PR TITLE
Use HTTP instead of SSH for Git clone

### DIFF
--- a/doc_source/getting-started-aws-copilot-cli.md
+++ b/doc_source/getting-started-aws-copilot-cli.md
@@ -18,7 +18,7 @@ Make sure that you have the AWS command line tool installed and have already run
 Deploy the application using the following command\.
 
 ```
-git clone git@github.com:aws-samples/amazon-ecs-cli-sample-app.git demo-app && \ 
+git clone https://github.com/aws-samples/amazon-ecs-cli-sample-app.git demo-app && \ 
 cd demo-app &&                               \
 copilot init --app demo                      \
   --name api                                 \
@@ -43,7 +43,7 @@ aws configure
 Clone a simple Flask application and Dockerfile\.
 
 ```
-git clone git@github.com:aws-samples/amazon-ecs-cli-sample-app.git demo-app
+git clone https://github.com/aws-samples/amazon-ecs-cli-sample-app.git demo-app
 ```
 
 ### Step 3: Set up your application<a name="getting-started-ecs-copilot-cli-setup-app"></a>


### PR DESCRIPTION
Since external users are not part of the repository, HTTPS should be used as protocol for Git operations instead of SSH.