### PR TITLE
Make it clear that task retirement notifications are only for standalone tasks

### DIFF
--- a/doc_source/task-retirement.md
+++ b/doc_source/task-retirement.md
@@ -6,13 +6,13 @@ A task can be scheduled for retirement in the following scenarios:
 + AWS detects the irreparable failure of the underlying hardware hosting the task\.
 + Your task uses the Fargate launch type and is running on a platform version that has a security vulnerability that requires you to replace the tasks by launching new tasks using a patched platform version\.
 
-If your task is scheduled for retirement, you receive an email before the event with the task ID and retirement date\. This email is sent to the address that's associated with your account, the same email address that you use to log in to the AWS Management Console\. If you use an email account that you do not check regularly, then you can use the [AWS Personal Health Dashboard](http://aws.amazon.com/premiumsupport/phd/) to determine if any of your tasks are scheduled for retirement\. To update the contact information for your account, go to the [Account Settings](https://console.aws.amazon.com/billing/home?#/account) page\.
+If your standalone task is scheduled for retirement, you receive an email before the event with the task ID and retirement date\. This email is sent to the address that's associated with your account, the same email address that you use to log in to the AWS Management Console\. If you use an email account that you do not check regularly, then you can use the [AWS Personal Health Dashboard](http://aws.amazon.com/premiumsupport/phd/) to determine if any of your tasks are scheduled for retirement\. To update the contact information for your account, go to the [Account Settings](https://console.aws.amazon.com/billing/home?#/account) page\.
 
 When a task reaches its scheduled retirement date, it is stopped or terminated by AWS\. If the task is part of a service, then the task is automatically stopped and the service scheduler launches a new one to replace it\. If you are using standalone tasks, then you receive notification of the task retirement and must launch new tasks to replace them\.
 
 ## Working with tasks scheduled for retirement<a name="task-retirement-working"></a>
 
-If the task is part of a service, then the task is automatically stopped, The service scheduler starts a new one to replace it after it reaches its scheduled retirement date\. If you would like to update your service tasks before the retirement date, you can use the following steps\. For more information, see [Updating a service](update-service.md)\.
+If the task is part of a service, then the task is automatically stopped, the service scheduler starts a new one to replace it after it reaches its scheduled retirement date\. If you would like to update your service tasks before the retirement date, you can use the following steps\. For more information, see [Updating a service](update-service.md)\.
 
 **To update a running service \(AWS Management Console\)**
 


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

We send task retirement notifications only for standalone ECS tasks. This PR makes it clear. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
