### PR TITLE
Unsupported instance types that should be removed

### DIFF
--- a/doc_source/container-instance-eni.md
+++ b/doc_source/container-instance-eni.md
@@ -156,7 +156,6 @@ Although other instance types are supported in the same instance family, the `c5
 |  c5a\.xlarge  | 3 |  20  | 
 |  c5a\.2xlarge  | 3 |  40  | 
 |  c5a\.4xlarge  | 7 | 60 | 
-|  c5a\.8xlarge  | 7 |  60  | 
 |  c5a\.12xlarge  | 7 |  60  | 
 |  c5a\.16xlarge  | 14 |  120  | 
 |  c5a\.18xlarge  | 14 |  120  | 
@@ -165,7 +164,6 @@ Although other instance types are supported in the same instance family, the `c5
 |  c5ad\.xlarge  | 3 | 20 | 
 |  c5ad\.2xlarge  | 3 | 40 | 
 |  c5ad\.4xlarge  | 7 | 60 | 
-|  c5ad\.8xlarge  | 7 | 60 | 
 |  c5ad\.12xlarge  | 7 | 60 | 
 |  c5ad\.16xlarge  | 14 | 120 | 
 |  c5ad\.18xlarge  | 14 | 120 | 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* c5ad.8xlarge and  c5a.8xlarge do not support ENI trunking and should be removed from the supported instance types.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
