### PR TITLE
Modified to use an existing role

### DIFF
--- a/doc_source/troubleshoot-task-iam-roles.md
+++ b/doc_source/troubleshoot-task-iam-roles.md
@@ -29,7 +29,7 @@ The following procedure helps you to:
 
    1. For **Select your use case**, choose **Elastic Container Service Task**, **Next: Permissions**\.
 
-   1. On the **Attached permissions policy** page, choose **AmazonEC2ContainerServiceFullAccess**, **Next: Review**\.
+   1. On the **Attached permissions policy** page, choose **AmazonECS_FullAccess**, **Next: Review**\.
 
    1. On the **Review** page, for **Role name**, enter `ECS-task-full-access` and choose **Create role**\.
 


### PR DESCRIPTION
*Issue #, if available:*
Doc references a role that no longer exists

*Description of changes:*
The role of AmazonEC2ContainerServiceFullAccess no longer exists. From my research, it appears that AmazonECS_FullAccess is the correct role to use here.

FYI - I used the inline editor to create this fork/change.  I only changed the Role name so I'm not sure why it has another section of text listed as removed and added.  It's the exact same text.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
