### PR TITLE
Capitalize Property Names

### DIFF
--- a/doc_source/taskdef-envfiles.md
+++ b/doc_source/taskdef-envfiles.md
@@ -12,16 +12,16 @@ The following is a snippet of a task definition showing how to specify individua
 
 ```
 {
-    "family": "",
-    "containerDefinitions": [
+    "Family": "",
+    "ContainerDefinitions": [
         {
-            "name": "",
-            "image": "",
+            "Name": "",
+            "Image": "",
             ...
-            "environment": [
+            "Environment": [
                 {
-                    "name": "variable",
-                    "value": "value"
+                    "Name": "variable",
+                    "Value": "value"
                 }
             ],
             ...
@@ -35,16 +35,16 @@ The following is a snippet of a task definition showing how to specify an enviro
 
 ```
 {
-    "family": "",
-    "containerDefinitions": [
+    "Family": "",
+    "ContainerDefinitions": [
         {
-            "name": "",
-            "image": "",
+            "Name": "",
+            "Image": "",
             ...
-            "environmentFiles": [
+            "EnvironmentFiles": [
                 {
-                    "value": "arn:aws:s3:::s3_bucket_name/envfile_object_name.env",
-                    "type": "s3"
+                    "Value": "arn:aws:s3:::s3_bucket_name/envfile_object_name.env",
+                    "Type": "s3"
                 }
             ],
             ...


### PR DESCRIPTION
Everywhere else in the docs properties are capitalized.
i.e.
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-environmentfile.html
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-environmentfiles

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
