### PR TITLE
Update task_definition_parameters.md

### DIFF
--- a/doc_source/task_definition_parameters.md
+++ b/doc_source/task_definition_parameters.md
@@ -476,8 +476,7 @@ The IP address to use in the `/etc/hosts` entry\.
 Type: Boolean  
 Required: no  
 When this parameter is true, the container is given read\-only access to its root file system\. This parameter maps to `ReadonlyRootfs` in the [Create a container](https://docs.docker.com/engine/api/v1.38/#operation/ContainerCreate) section of the [Docker Remote API](https://docs.docker.com/engine/api/v1.38/) and the `--read-only` option to [https://docs.docker.com/engine/reference/commandline/run/](https://docs.docker.com/engine/reference/commandline/run/)\.  
-This parameter is not supported for Windows containers\.
-
+This parameter is not supported for Windows containers or containers hosted on Fargate\.
 ```
 "readonlyRootFilesystem": true|false
 ```


### PR DESCRIPTION
Changed readonlyrootfilesystem to reflect that Fargate Containers also cannot support this parameter.

*Issue #, if available:*

*Description of changes:* Fargate containers do not work with the readonlyrootfilesystem parameter enabled. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
