### PR TITLE
Update tutorial-wfsx-volumes.md

### DIFF
--- a/doc_source/tutorial-wfsx-volumes.md
+++ b/doc_source/tutorial-wfsx-volumes.md
@@ -317,19 +317,6 @@ The Fargate launch type isn't compatible with Windows containers\.
                        "readOnly": false
                    }
                ],
-               "volumes": [
-                   {
-                       "name": "fsx-windows-vol",
-                       "fsxWindowsFileServerVolumeConfiguration": {
-                           "fileSystemId": "fs-0eeb5730b2EXAMPLE",
-                           "authorizationConfig": {
-                               "domain": "example.com",
-                               "credentialsParameter": "arn:arn-1234"
-                           },
-                           "rootDirectory": "share"
-                       }
-                   }
-               ],
                "cpu": 512,
                "memory": 256,
                "image": "mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019",


### PR DESCRIPTION
Using the sample task definition JSON will throw and error: Unable to create Task definition 

*Issue #196  *

*Description of changes:*
Update sample task definition.
1. Removed FSx volume syntax section in the task definition since the next step in the tutorial is a procedure to directly Add volume.
2. If FSx volume must be added in the sample task definition for tasks that use a FSx mount volume, the task definition JSON syntax for the volumes and mountPoints objects for a container should not be on the same line. For example

```
		"mountPoints": [{
			"sourceVolume": "fsx-windows-vol",
			"containerPath": "C:\fsx-windows-data",
			"readOnly": false
		}]
	}],
	"volumes": [{
		"name": "fsx-windows-vol",
		"fsxWindowsFileServerVolumeConfiguration": {
			"fileSystemId": "fs-ID",
			"authorizationConfig": {
				"domain": "example.com",
				"credentialsParameter": "arn:arn-1234"
			},
			"rootDirectory": "share"
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
