### PR TITLE
Update snippet wfsx-volumes.md

### DIFF
--- a/doc_source/wfsx-volumes.md
+++ b/doc_source/wfsx-volumes.md
@@ -80,19 +80,6 @@ To use FSx for Windows File Server file system volumes for your containers, you 
                     "readOnly": false
                 }
             ],
-            "volumes": [
-                {
-                    "name": "fsx-windows-vol",
-                    "fsxWindowsFileServerVolumeConfiguration": {
-                        "fileSystemId": "fs-0eeb5730b2EXAMPLE",
-                        "authorizationConfig": {
-                            "domain": "example.com",
-                            "credentialsParameter": "arn:arn-1234"
-                        },
-                        "rootDirectory": "share"
-                    }
-                }
-            ],
             "cpu": 512,
             "memory": 256,
             "image": "mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019",
@@ -100,6 +87,19 @@ To use FSx for Windows File Server file system volumes for your containers, you 
             "name": "container2"
         }
     ],
+    "volumes": [
+        {
+            "name": "fsx-windows-vol",
+            "fsxWindowsFileServerVolumeConfiguration": {
+                "fileSystemId": "fs-0eeb5730b2EXAMPLE",
+                "authorizationConfig": {
+                    "domain": "example.com",
+                    "credentialsParameter": "arn:arn-1234"
+                },
+                "rootDirectory": "share"
+            }
+        }
+    ],    
     "family": "fsx-windows"
 }
 ```


### PR DESCRIPTION
Update task definition JSON snippet wfsx-volumes.md
mountPoints and volumes should be on different indented lines

*Issue #196*

*Description of changes:*
Modified the task definition JSON snippet with the correct syntax for the volumes and mountPoints objects for a container:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
