### PR TITLE
Add note for ECS Service Event reporting periodically

### DIFF
--- a/doc_source/ecs_cwe_events.md
+++ b/doc_source/ecs_cwe_events.md
@@ -310,7 +310,7 @@ Amazon ECS sends events with `INFO`, `WARN`, and `ERROR` event types\. The follo
 ### Service action events with `INFO` event type<a name="ecs_service_events_info_type"></a>
 
 `SERVICE_STEADY_STATE`  
-The service is healthy and at the desired number of tasks, thus reaching a steady state\.
+The service is healthy and at the desired number of tasks, thus reaching a steady state\. The service scheduler reports the status periodically, so you might receive this message multiple times\.
 
 `TASKSET_STEADY_STATE`  
 The task set is healthy and at the desired number of tasks, thus reaching a steady state\.


### PR DESCRIPTION
Include note on "service (service-name) has reached a steady state"
> The service scheduler reports the status periodically, so you might receive this message multiple times.

(found elsewhere https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-event-messages.html#service-event-messages-list)

*Issue #, if available:*

*Description of changes:*
This is a small change. It includes a note that an ECS Service Event will be reported periodically.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
