### PR TITLE
Fix typo in deployment status checks example table

### DIFF
--- a/doc_source/deployment-type-ecs.md
+++ b/doc_source/deployment-type-ecs.md
@@ -71,7 +71,7 @@ The following table provides some examples\.
 | --- | --- | --- | 
 |  1  |  <pre>10 <= 0.5 * 1 => 200</pre>  | 10 \(the calculated value is less than the minimum\) | 
 |  25  |  <pre>10 <= 0.5 * 25 => 200</pre>  | 13 \(the value is rounded up\) | 
-|  400  |  <pre>10 <= 0.5 * 200 => 200</pre>  | 200 | 
+|  400  |  <pre>10 <= 0.5 * 400 => 200</pre>  | 200 | 
 |  800  |  <pre>10 <= 0.5 * 800 => 200</pre>  | 200 \(the calculated value is greater than the maximum\) | 
 
 For additional examples about using the rollback option, see [Announcing Amazon ECS deployment circuit breaker](https://aws.amazon.com/blogs/containers/announcing-amazon-ecs-deployment-circuit-breaker/)\.


### PR DESCRIPTION
*Issue #, if available:* No issue number

*Description of changes:* Each row of this table is supposed to show the desired service count multiplied by 0.5 interacting with minimums, maximums, and rounding. The third row mistakenly shows 0.5 * 200 = 200 for a row that represents a desired service count of 400. It should be 0.5 * 400 = 200, which fixes the math and makes the row self-consistent.