### PR TITLE
GetParameters->GetParameter

### DIFF
--- a/doc_source/specifying-sensitive-data-parameters.md
+++ b/doc_source/specifying-sensitive-data-parameters.md
@@ -34,7 +34,7 @@ To use this feature, you must have the Amazon ECS task execution role and refere
 For tasks that use the EC2 launch type, you must use the ECS agent configuration variable `ECS_ENABLE_AWSLOGS_EXECUTIONROLE_OVERRIDE=true` to use this feature\. You can add it to the `./etc/ecs/ecs.config` file during container instance creation or you can add it to an existing instance and then restart the ECS agent\. For more information, see [Amazon ECS container agent configuration](ecs-agent-config.md)\.
 
 To provide access to the AWS Systems Manager Parameter Store parameters that you create, manually add the following permissions as an inline policy to the task execution role\. For more information, see [Adding and Removing IAM Policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_manage-attach-detach.html)\.
-+ `ssm:GetParameters`—Required if you are referencing a Systems Manager Parameter Store parameter in a task definition\.
++ `ssm:GetParameter`—Required if you are referencing a Systems Manager Parameter Store parameter in a task definition\.
 + `secretsmanager:GetSecretValue`—Required if you are referencing a Secrets Manager secret either directly or if your Systems Manager Parameter Store parameter is referencing a Secrets Manager secret in a task definition\.
 + `kms:Decrypt`—Required only if your secret uses a custom KMS key and not the default key\. The ARN for your custom key should be added as a resource\.
 
@@ -47,7 +47,7 @@ The following example inline policy adds the required permissions:
     {
       "Effect": "Allow",
       "Action": [
-        "ssm:GetParameters",
+        "ssm:GetParameter",
         "secretsmanager:GetSecretValue",
         "kms:Decrypt"
       ],


### PR DESCRIPTION
Ref: [CASE 10096430381] Chat: Job cannot connect to SSM and parameter store
IAM role to have permission "ssm:GetParameter" instead of "ssm:GetParameters"

*Issue #, if available:*
10096430381
*Description of changes:*
We tried to add permission  "ssm:GetParameters" as provided in the documentation [Specifying sensitive data using Systems Manager Parameter Store - Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-parameters.html) 
But, did not work. Hence the CASE 1009643038 was created and resolved by removing "s" from "GetParameters"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
