### PR TITLE
Update getting-started-aws-copilot-cli.md

### DIFF
--- a/doc_source/getting-started-aws-copilot-cli.md
+++ b/doc_source/getting-started-aws-copilot-cli.md
@@ -53,6 +53,7 @@ git clone https://github.com/aws-samples/amazon-ecs-cli-sample-app.git demo-app
    ```
    copilot init
    ```
+   For Windows users, run the `init` command from the folder where the copilot.exe file was downloaded.
 
    AWS Copilot walks you through the setup of your **first application and service** with a series of terminal prompts, starting with **next step**\. If you have already used AWS Copilot to deploy applications, you're prompted to choose one from a list of application names\.
 
@@ -94,6 +95,8 @@ git clone https://github.com/aws-samples/amazon-ecs-cli-sample-app.git demo-app
    ```
 
     Choose *`Dockerfile`*\. 
+    
+    For Windows users, enter the path to the Dockerfile in the demo-app folder. *`...\demo-app\Dockerfile`*\.
 
 1. Define port\.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

For Windows, the "copilot init" command is not recognized outside of the folder where "copilot.exe" is downloaded. After initialization,  provide the custom path to the Dockerfile in your app folder.

![image](https://user-images.githubusercontent.com/81542713/187223235-7ffa35c8-6a98-4f59-b698-370f8de4c7a6.png)

![image](https://user-images.githubusercontent.com/81542713/187223488-f40b84af-ad78-45f7-b8cc-70addba02b76.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
