### PR TITLE
resolve #219 copilot docker daemon not responsive

### DIFF
--- a/doc_source/docker-daemon-is-not-responsive.md
+++ b/doc_source/docker-daemon-is-not-responsive.md
@@ -1,0 +1,15 @@
+# Docker daemon is not responsive<a name="docker-daemon-is-not-responsive"></a>
+
+AWS Copilot can use a provided Dockerfile to build a container image for the application.
+To do this a running Docker daemon is necessary.
+
+If the following message appears after a *copilot init* command, it may indicate that a docker daemon is not available.
+
+  ```
+  Docker daemon is not responsive; Copilot won't build from a Dockerfile.
+  ```
+
+If copilot does not detect a running Docker daemon it will not be able to build a new docker image for the application.
+
+If a docker image for the application already exists, the image location can be provided and the process continued.
+Otherwise, start a docker daemon and retry the desired copilot command.

--- a/doc_source/troubleshooting.md
+++ b/doc_source/troubleshooting.md
@@ -20,3 +20,4 @@ You may need to troubleshoot issues with your load balancers, tasks, services, o
 + [AWS Fargate throttling quotas](throttling.md)
 + [API failure reasons](api_failures_messages.md)
 + [Troubleshooting IAM Roles for Tasks](troubleshoot-task-iam-roles.md)
++ [Docker daemon is not responsive](docker-daemon-is-not-responsive.md)


### PR DESCRIPTION
*Issue #, if available:* 219

*Description of changes:*
When using AWS Copilot, if a docker daemon is not detected, an image build ability will not be available, but copilot can proceed if an existing image is available. This change is to include the warning from copilot and the meaning.

Files changed:
* add new file doc_source/docker-daemon-is-not-responsive.md to cover docker daemon not detected and meaning
* modify doc_source/troubleshooting.md to link new troubleshooting entry

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
