### PR TITLE
Fix incorrect reference to 'Full' within 'Core' sections.

### DIFF
--- a/doc_source/ecs-windows-ami-versions.md
+++ b/doc_source/ecs-windows-ami-versions.md
@@ -47,7 +47,7 @@ The table below lists the current and previous versions of the Amazon ECS\-optim
 |  **Windows\_Server\-2022\-English\-Core\-ECS\_Optimized\-2021\.11\.11**  |  `1.57.0`  |  `20.10.7`  |  Public  | 
 |  **Windows\_Server\-2022\-English\-Core\-ECS\_Optimized\-2021\.009\.23**  |  `1.55.3`  |  `20.10.7`  |  Public  | 
 
-Use the following AWS CLI command to retrieve the current Amazon ECS\-optimized Windows Server 2022 Full AMI\.
+Use the following AWS CLI command to retrieve the current Amazon ECS\-optimized Windows Server 2022 Core AMI\.
 
 ```
 aws ssm get-parameters --names /aws/service/ami-windows-latest/Windows_Server-2022-English-Core-ECS_Optimized
@@ -134,7 +134,7 @@ The table below lists the current and previous versions of the Amazon ECS\-optim
 |  **Windows\_Server\-2019\-English\-Core\-ECS\_Optimized\-2019\.11\.13**  |  `1.32.1`  |  `19.03.4`  |  Private  | 
 |  **Windows\_Server\-2019\-English\-Core\-ECS\_Optimized\-2019\.10\.09**  |  `1.32.0`  |  `19.03.2`  |  Private  | 
 
-Use the following AWS CLI command to retrieve the current Amazon ECS\-optimized Windows Server 2019 Full AMI\.
+Use the following AWS CLI command to retrieve the current Amazon ECS\-optimized Windows Server 2019 Core AMI\.
 
 ```
 aws ssm get-parameters --names /aws/service/ami-windows-latest/Windows_Server-2019-English-Core-ECS_Optimized


### PR DESCRIPTION
*Issue #, if available:*
No Issue, documentation fixes.
*Description of changes:*
In the Core AMI sections, fix incorrect reference of 'Full'. Should be 'Core'


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
