### PR TITLE
Updated "Update Service" with information that health check grace per…

### DIFF
--- a/doc_source/new-console.md
+++ b/doc_source/new-console.md
@@ -53,7 +53,7 @@ The following task options require the classic console:
 The following service options require the classic console:
 + **Service Discovery** \- You can only view your Service Discovery configuration\. 
 + **Step scaling policies for service auto scaling**
-+ **Update Service** \- You cannot update the `awsvpc` network configuration\.
++ **Update Service** \- You cannot update the `awsvpc` network configuration and health check grace period\.
 
 ### Container instances<a name="classic-console-instances"></a>
 


### PR DESCRIPTION
…iod update is not possible.

*Issue #, if available:* -NA-

*Description of changes:*
The new console doesn't support updating health check grace period when updating the service. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
