### PR TITLE
Update nvidia/cuda version to now read nvidia/cuda:11.0.3-base

### DIFF
--- a/doc_source/ecs-gpu.md
+++ b/doc_source/ecs-gpu.md
@@ -106,7 +106,7 @@ The following example demonstrates the syntax for a Docker container that specif
       "memory": 80,
       "essential": true,
       "name": "gpu",
-      "image": "nvidia/cuda:11.0-base",
+      "image": "nvidia/cuda:11.0.3-base",
       "resourceRequirements": [
          {
            "type":"GPU",


### PR DESCRIPTION
nvidia/cuda:11.0-base is no longer valid.  nvidia/cuda:11.0.3-base is now the correct version.  You will get an error if you try to pull this container.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
