### PR TITLE
Update: private-auth-container-instances.md - Dockerhub auth update

### DIFF
--- a/doc_source/private-auth-container-instances.md
+++ b/doc_source/private-auth-container-instances.md
@@ -61,6 +61,8 @@ ECS_ENGINE_AUTH_TYPE=dockercfg
 ECS_ENGINE_AUTH_DATA={"https://index.docker.io/v1/":{"auth":"zq212MzEXAMPLE7o6T25Dk0i","email":"email@example.com"}}
 ```
 
+If you are having trouble authenticating to Dockerhub with an `/etc/ecs/ecs.config` like the above example, the problem may be in your `auth` string.  Dockerhub may require `<username:auth_token>` in a Base64 encoded format.
+
 You can configure multiple private registries with the following syntax:
 
 ```


### PR DESCRIPTION
Based on my troubleshooting and subsequent success, it appears `/etc/ecs/ecs.config`, at least in some if not all cases, needs the `auth` string to be `<username>:<auth_token>` as a Base64 encoded string to work.  Adding this here for others who may be fighting the same issue.