### PR TITLE
Update Bottlerocket FireLens support information

### DIFF
--- a/doc_source/ecs-bottlerocket.md
+++ b/doc_source/ecs-bottlerocket.md
@@ -21,6 +21,7 @@ Consider the following when using a Bottlerocket AMI with Amazon ECS\.
 + Amazon EC2 instances with x86 or arm64 processors are supported\.
 + Amazon EC2 instances with Inferentia chips are not supported\.
 + The `awsvpc` network mode is supported when using Bottlerocket AMI version `1.1.0` or later\.
++ FireLens is supported when using Bottlerocket AMI version `1.13.0` or later\.
 + The `initProcessEnabled` task definition parameter is not supported\.
 + The following features are not supported:
   + App Mesh in task definitions
@@ -29,7 +30,6 @@ Consider the following when using a Bottlerocket AMI with Amazon ECS\.
   + Amazon EFS file system volumes
   + Amazon EFS in encrypted mode and `awsvpc` network mode
   + Elastic Inference
-  + FireLens in task definitions
 
 ## Retrieving an Amazon ECS\-optimized Bottlerocket AMI<a name="ecs-bottlerocket-retrieve-ami"></a>
 

--- a/doc_source/using_firelens.md
+++ b/doc_source/using_firelens.md
@@ -15,7 +15,7 @@ Consider the following when using FireLens for Amazon ECS:
 + For tasks that use the `bridge` network mode, the container with the FireLens configuration must start before any application containers that rely on it start\. To control the start order of your containers, use dependency conditions in your task definition\. For more information, see [Container dependency](task_definition_parameters.md#container_definition_dependson)\.
 **Note**  
 If you use dependency condition parameters in container definitions with a FireLens configuration, ensure that each container has a `START` or `HEALTHY` condition requirement\.
-+ The Amazon ECS\-optimized Bottlerocket AMI doesn't support FireLens\.
++ Amazon ECS\-optimized Bottlerocket AMIs prior to the Bottlerocket `v1.13.0` release do not support FireLens\.
 + By default, FireLens adds the cluster and task definition name and the Amazon Resource Name \(ARN\) of the cluster as metadata keys to your stdout/stderr container logs\. The following is an example of the metadata format\.
 
   ```


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

The upcoming Bottlerocket v1.13.0 release has enabled support for ECS FireLens. This updates the documentation for Bottlerocket to reflect support is now available in 1.13.0 or later.

The Bottlerocket 1.13.0 release is currently planned for mid-March 2023.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
