### PR TITLE
Update task-scale-in-protection-endpoint.md

### DIFF
--- a/doc_source/task-scale-in-protection-endpoint.md
+++ b/doc_source/task-scale-in-protection-endpoint.md
@@ -18,7 +18,7 @@ A PUT request to this URI from within a container will set task scale\-in protec
 
 ## Task scale\-in protection endpoint request<a name="task-scale-in-protection-request"></a>
 
-You can set task scale\-in protection using the `(${ECS_AGENT_URI}/task-protection/v1/state)` endpoint with the following request parameters\.
+You can set task scale\-in protection using the \(`${ECS_AGENT_URI}/task-protection/v1/state`\) endpoint with the following request parameters\.
 
 ### Protect<a name="w241aac21c30c11c13b5"></a>
 

--- a/doc_source/task-scale-in-protection-endpoint.md
+++ b/doc_source/task-scale-in-protection-endpoint.md
@@ -18,7 +18,7 @@ A PUT request to this URI from within a container will set task scale\-in protec
 
 ## Task scale\-in protection endpoint request<a name="task-scale-in-protection-request"></a>
 
-You can set task scale\-in protection using the `(${ECS_AGENT_URI/task-protection/v1/state})` endpoint with the following request parameters\.
+You can set task scale\-in protection using the `(${ECS_AGENT_URI}/task-protection/v1/state)` endpoint with the following request parameters\.
 
 ### Protect<a name="w241aac21c30c11c13b5"></a>
 
@@ -64,7 +64,7 @@ PUT $ECS_AGENT_URI/task-protection/v1/state -d
 
 ## Task scale\-in protection endpoint response<a name="task-scale-in-protection-response"></a>
 
-The following information is returned from the task scale\-in protection endpoint \(`${ECS_AGENT_URI/task-protection/v1/state}`\) JSON response\.
+The following information is returned from the task scale\-in protection endpoint \(`${ECS_AGENT_URI}/task-protection/v1/state`\) JSON response\.
 
 ### Protect<a name="w241aac21c30c11c15b5"></a>
 


### PR DESCRIPTION
Correct location of `}`. The old notation would try to perform a string replacement.

*Issue #, if available:*

*Description of changes:*

If you try to use the code as listed, you won't get the correct URL. This shows the problem:

```
$ echo ${ECS_AGENT_URI/task-protection/v1/state}
http://169.254.170.2/api/e88ce5c211202c51f9674ec564431b32-4213330123
$ echo ${ECS_AGENT_URI}/task-protection/v1/state
http://169.254.170.2/api/e88ce5c211202c51f9674ec564431b32-4213330123/task-protection/v1/state
```

Could also potentially remove both `{` and `}`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
